### PR TITLE
fix(lint): Re-add `goerr113` to enabled linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -184,6 +184,7 @@ linters:
     - gocritic
     - gocyclo
     - godot
+    - goerr113
     - gofmt
     - gomnd
     - goprintffuncname


### PR DESCRIPTION
Re-enabling `goerr113` as it was a misunderstanding to disable it. Seeing it in the disabled linters made me think it was not supposed to be enabled, but it was in fact disabled only for Go tests (as intended). 

This PR enables the linter and would fix any warnings raised by it, but there were none. 

For context, the linter raises warnings over sentinel errors in returns that are declared anonymously / in-place. This library uses `github.com/zalgonoise/x/errs` to create sentinel errors, and having so covers warnings raised by this linter.

Closes #5 