### PR TITLE
feat: [schedule] Add schedule builder logic

### DIFF
--- a/schedule/builder/builder.go
+++ b/schedule/builder/builder.go
@@ -1,0 +1,482 @@
+package builder
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/zalgonoise/micron/schedule/cronlex"
+	"github.com/zalgonoise/micron/schedule/resolve"
+)
+
+const (
+	seconds = iota
+	minutes
+	hours
+	monthDays
+	months
+	weekdays
+)
+
+const (
+	Sunday = iota
+	Monday
+	Tuesday
+	Wednesday
+	Thursday
+	Friday
+	Saturday
+)
+
+const (
+	minSecond = 0
+	maxSecond = 59
+
+	minMinute = 0
+	maxMinute = 59
+
+	minHour = 0
+	maxHour = 23
+
+	minDay = 1
+	maxDay = 31
+
+	minMonth = 1
+	maxMonth = 12
+
+	minWeekday = 0
+	maxWeekday = 7
+)
+
+var (
+	ErrInvalidCategory = errors.New("invalid category")
+	ErrInvalidResolver = errors.New("invalid resolver type")
+	ErrOutOfBounds     = errors.New("value is out-of-bounds")
+)
+
+type Scheduler interface {
+	Seconds() Resolver
+	Minutes() Resolver
+	Hours() Resolver
+	MonthDays() Resolver
+	Months() Resolver
+	Weekdays() Resolver
+}
+
+type Resolver struct {
+	category int
+	resolver cronlex.Resolver
+}
+
+type schedule struct {
+	value int
+}
+
+func (s schedule) Seconds() Resolver {
+	if s.value < 0 {
+		return Resolver{
+			category: seconds,
+			resolver: resolve.Everytime{},
+		}
+	}
+
+	return Resolver{
+		category: seconds,
+		resolver: resolve.FixedSchedule{
+			Max: maxSecond,
+			At:  s.value,
+		},
+	}
+}
+
+func (s schedule) Minutes() Resolver {
+	if s.value < 0 {
+		return Resolver{
+			category: minutes,
+			resolver: resolve.Everytime{},
+		}
+	}
+
+	return Resolver{
+		category: minutes,
+		resolver: resolve.FixedSchedule{
+			Max: maxMinute,
+			At:  s.value,
+		},
+	}
+}
+
+func (s schedule) Hours() Resolver {
+	if s.value < 0 {
+		return Resolver{
+			category: hours,
+			resolver: resolve.Everytime{},
+		}
+	}
+
+	return Resolver{
+		category: hours,
+		resolver: resolve.FixedSchedule{
+			Max: maxHour,
+			At:  s.value,
+		},
+	}
+}
+
+func (s schedule) MonthDays() Resolver {
+	if s.value < 0 {
+		return Resolver{
+			category: monthDays,
+			resolver: resolve.Everytime{},
+		}
+	}
+
+	return Resolver{
+		category: monthDays,
+		resolver: resolve.FixedSchedule{
+			Max: maxDay,
+			At:  s.value,
+		},
+	}
+}
+
+func (s schedule) Months() Resolver {
+	if s.value < 0 {
+		return Resolver{
+			category: months,
+			resolver: resolve.Everytime{},
+		}
+	}
+
+	return Resolver{
+		category: months,
+		resolver: resolve.FixedSchedule{
+			Max: maxMonth,
+			At:  s.value,
+		},
+	}
+}
+
+func (s schedule) Weekdays() Resolver {
+	if s.value < 0 {
+		return Resolver{
+			category: weekdays,
+			resolver: resolve.Everytime{},
+		}
+	}
+
+	return Resolver{
+		category: weekdays,
+		resolver: resolve.FixedSchedule{
+			Max: maxWeekday,
+			At:  s.value,
+		},
+	}
+}
+
+func All() Scheduler {
+	return schedule{value: -1}
+}
+
+func Every(n int) Scheduler {
+	return schedule{value: n}
+}
+
+type rangeSchedule struct {
+	from, to int
+}
+
+func (s rangeSchedule) Seconds() Resolver {
+	return Resolver{
+		category: seconds,
+		resolver: resolve.RangeSchedule{
+			Max:  maxSecond,
+			From: s.from,
+			To:   s.to,
+		},
+	}
+}
+
+func (s rangeSchedule) Minutes() Resolver {
+	return Resolver{
+		category: minutes,
+		resolver: resolve.RangeSchedule{
+			Max:  maxMinute,
+			From: s.from,
+			To:   s.to,
+		},
+	}
+}
+
+func (s rangeSchedule) Hours() Resolver {
+	return Resolver{
+		category: hours,
+		resolver: resolve.RangeSchedule{
+			Max:  maxHour,
+			From: s.from,
+			To:   s.to,
+		},
+	}
+}
+
+func (s rangeSchedule) MonthDays() Resolver {
+	return Resolver{
+		category: monthDays,
+		resolver: resolve.RangeSchedule{
+			Max:  maxDay,
+			From: s.from,
+			To:   s.to,
+		},
+	}
+}
+
+func (s rangeSchedule) Months() Resolver {
+	return Resolver{
+		category: months,
+		resolver: resolve.RangeSchedule{
+			Max:  maxMonth,
+			From: s.from,
+			To:   s.to,
+		},
+	}
+}
+
+func (s rangeSchedule) Weekdays() Resolver {
+	return Resolver{
+		category: weekdays,
+		resolver: resolve.RangeSchedule{
+			Max:  maxWeekday,
+			From: s.from,
+			To:   s.to,
+		},
+	}
+}
+
+func Range(from, to int) Scheduler {
+	return rangeSchedule{
+		from: from,
+		to:   to,
+	}
+}
+
+type stepSchedule struct {
+	values []int
+}
+
+func (s stepSchedule) Seconds() Resolver {
+	return Resolver{
+		category: seconds,
+		resolver: resolve.StepSchedule{
+			Max:   maxSecond,
+			Steps: s.values,
+		},
+	}
+}
+
+func (s stepSchedule) Minutes() Resolver {
+	return Resolver{
+		category: minutes,
+		resolver: resolve.StepSchedule{
+			Max:   maxMinute,
+			Steps: s.values,
+		},
+	}
+}
+
+func (s stepSchedule) Hours() Resolver {
+	return Resolver{
+		category: hours,
+		resolver: resolve.StepSchedule{
+			Max:   maxHour,
+			Steps: s.values,
+		},
+	}
+}
+
+func (s stepSchedule) MonthDays() Resolver {
+	return Resolver{
+		category: monthDays,
+		resolver: resolve.StepSchedule{
+			Max:   maxDay,
+			Steps: s.values,
+		},
+	}
+}
+
+func (s stepSchedule) Months() Resolver {
+	return Resolver{
+		category: months,
+		resolver: resolve.StepSchedule{
+			Max:   maxMonth,
+			Steps: s.values,
+		},
+	}
+}
+
+func (s stepSchedule) Weekdays() Resolver {
+	return Resolver{
+		category: weekdays,
+		resolver: resolve.StepSchedule{
+			Max:   maxWeekday,
+			Steps: s.values,
+		},
+	}
+}
+
+func On(values ...int) Scheduler {
+	return stepSchedule{values: values}
+}
+
+func Build(resolvers ...Resolver) (cronlex.Schedule, error) {
+	sched := cronlex.Schedule{}
+	cache := map[int]struct{}{}
+
+	for i := range resolvers {
+		if err := validateResolver(resolvers[i]); err != nil {
+			return cronlex.Schedule{}, err
+		}
+
+		switch resolvers[i].category {
+		case seconds:
+			sched.Sec = resolvers[i].resolver
+			cache[0] = struct{}{}
+		case minutes:
+			sched.Min = resolvers[i].resolver
+			cache[1] = struct{}{}
+		case hours:
+			sched.Hour = resolvers[i].resolver
+			cache[2] = struct{}{}
+		case monthDays:
+			sched.DayMonth = resolvers[i].resolver
+			cache[3] = struct{}{}
+		case months:
+			sched.Month = resolvers[i].resolver
+			cache[4] = struct{}{}
+		case weekdays:
+			sched.DayWeek = resolvers[i].resolver
+			cache[5] = struct{}{}
+		}
+	}
+
+	var start bool
+	switch {
+	case sched.Sec == nil:
+		sched.Sec = resolve.FixedSchedule{Max: maxSecond, At: minSecond}
+	default:
+		start = true
+	}
+
+	switch {
+	case sched.Min == nil && !start:
+		sched.Min = resolve.FixedSchedule{Max: maxMinute, At: minMinute}
+	case sched.Min == nil:
+		sched.Min = resolve.Everytime{}
+	default:
+		start = true
+	}
+
+	switch {
+	case sched.Hour == nil && !start:
+		sched.Hour = resolve.FixedSchedule{Max: maxHour, At: minHour}
+	case sched.Hour == nil:
+		sched.Hour = resolve.Everytime{}
+	default:
+		start = true
+	}
+
+	if sched.DayWeek == nil {
+		switch {
+		case sched.DayMonth == nil && !start:
+			sched.DayMonth = resolve.FixedSchedule{Max: maxDay, At: minDay}
+		case sched.DayMonth == nil:
+			sched.DayMonth = resolve.Everytime{}
+		default:
+			start = true
+		}
+
+		switch {
+		case sched.Month == nil && !start:
+			sched.Month = resolve.FixedSchedule{Max: maxMonth, At: minMonth}
+		case sched.Month == nil:
+			sched.Month = resolve.Everytime{}
+		default:
+			start = true
+		}
+
+		sched.DayWeek = resolve.Everytime{}
+
+		return sched, nil
+	}
+
+	sched.DayMonth = resolve.Everytime{}
+	sched.Month = resolve.Everytime{}
+
+	switch {
+	case sched.DayWeek == nil && !start:
+		sched.DayWeek = resolve.FixedSchedule{Max: maxWeekday, At: minWeekday}
+	case sched.DayWeek == nil:
+		sched.DayWeek = resolve.Everytime{}
+	default:
+		start = true
+	}
+
+	return sched, nil
+}
+
+func validateResolver(r Resolver) error {
+	switch r.category {
+	case seconds:
+		return validate(r, minSecond)
+	case minutes:
+		return validate(r, minMinute)
+	case hours:
+		return validate(r, minHour)
+	case monthDays:
+		return validate(r, minDay)
+	case months:
+		return validate(r, minMonth)
+	case weekdays:
+		return validate(r, minWeekday)
+	default:
+		return fmt.Errorf("%w: %d", ErrInvalidCategory, r.category)
+	}
+}
+
+func validate(r Resolver, minimum int) error {
+	switch v := r.resolver.(type) {
+	case resolve.Everytime:
+		// valid
+
+		return nil
+	case resolve.FixedSchedule:
+		if v.At < minimum || v.At > v.Max {
+			return fmt.Errorf("%w: %d", ErrOutOfBounds, v.At)
+		}
+
+		return nil
+
+	case resolve.RangeSchedule:
+		var err error
+
+		if v.From < minimum || v.From > v.Max {
+			err = fmt.Errorf("%w: from: %d", ErrOutOfBounds, v.From)
+		}
+
+		if v.To < minimum || v.To > v.Max {
+			return errors.Join(err, fmt.Errorf("%w: to: %d", ErrOutOfBounds, v.From))
+		}
+
+		return err
+	case resolve.StepSchedule:
+		errs := make([]error, 0, len(v.Steps))
+
+		for i := range v.Steps {
+			if v.Steps[i] < minimum || v.Steps[i] > v.Max {
+				errs = append(errs, fmt.Errorf("%w: step #%d: %d", ErrOutOfBounds, i, v.Steps[i]))
+			}
+		}
+
+		return errors.Join(errs...)
+	default:
+		return fmt.Errorf("%w: %#v", ErrInvalidResolver, r)
+	}
+}

--- a/schedule/builder/builder_test.go
+++ b/schedule/builder/builder_test.go
@@ -119,85 +119,31 @@ func TestBuild(t *testing.T) {
 			sched, err := Build(testcase.resolvers...)
 
 			isEqual(t, true, errors.Is(err, testcase.err))
-			if steps, ok := testcase.wants.Sec.(resolve.StepSchedule); ok {
-				got, ok := sched.Sec.(resolve.StepSchedule)
-
-				isEqual(t, true, ok)
-
-				isEqual(t, steps.Max, got.Max)
-				for i := range steps.Steps {
-					isEqual(t, steps.Steps[i], got.Steps[i])
-				}
-			} else {
-				isEqual(t, testcase.wants.Sec, sched.Sec)
-			}
-
-			if steps, ok := testcase.wants.Min.(resolve.StepSchedule); ok {
-				got, ok := sched.Min.(resolve.StepSchedule)
-
-				isEqual(t, true, ok)
-
-				isEqual(t, steps.Max, got.Max)
-				for i := range steps.Steps {
-					isEqual(t, steps.Steps[i], got.Steps[i])
-				}
-			} else {
-				isEqual(t, testcase.wants.Min, sched.Min)
-			}
-
-			if steps, ok := testcase.wants.Hour.(resolve.StepSchedule); ok {
-				got, ok := sched.Hour.(resolve.StepSchedule)
-
-				isEqual(t, true, ok)
-
-				isEqual(t, steps.Max, got.Max)
-				for i := range steps.Steps {
-					isEqual(t, steps.Steps[i], got.Steps[i])
-				}
-			} else {
-				isEqual(t, testcase.wants.Hour, sched.Hour)
-			}
-
-			if steps, ok := testcase.wants.DayMonth.(resolve.StepSchedule); ok {
-				got, ok := sched.DayMonth.(resolve.StepSchedule)
-
-				isEqual(t, true, ok)
-
-				isEqual(t, steps.Max, got.Max)
-				for i := range steps.Steps {
-					isEqual(t, steps.Steps[i], got.Steps[i])
-				}
-			} else {
-				isEqual(t, testcase.wants.DayMonth, sched.DayMonth)
-			}
-
-			if steps, ok := testcase.wants.Month.(resolve.StepSchedule); ok {
-				got, ok := sched.Month.(resolve.StepSchedule)
-
-				isEqual(t, true, ok)
-
-				isEqual(t, steps.Max, got.Max)
-				for i := range steps.Steps {
-					isEqual(t, steps.Steps[i], got.Steps[i])
-				}
-			} else {
-				isEqual(t, testcase.wants.Month, sched.Month)
-			}
-
-			if steps, ok := testcase.wants.DayWeek.(resolve.StepSchedule); ok {
-				got, ok := sched.DayWeek.(resolve.StepSchedule)
-
-				isEqual(t, true, ok)
-
-				isEqual(t, steps.Max, got.Max)
-				for i := range steps.Steps {
-					isEqual(t, steps.Steps[i], got.Steps[i])
-				}
-			} else {
-				isEqual(t, testcase.wants.DayWeek, sched.DayWeek)
-			}
+			isEqualResolver(t, testcase.wants.Sec, sched.Sec)
+			isEqualResolver(t, testcase.wants.Min, sched.Min)
+			isEqualResolver(t, testcase.wants.Hour, sched.Hour)
+			isEqualResolver(t, testcase.wants.DayMonth, sched.DayMonth)
+			isEqualResolver(t, testcase.wants.Month, sched.Month)
+			isEqualResolver(t, testcase.wants.DayWeek, sched.DayWeek)
 		})
 	}
+}
+
+func isEqualResolver(t *testing.T, wants, got cronlex.Resolver) {
+	if steps, ok := wants.(resolve.StepSchedule); ok {
+		got, ok := got.(resolve.StepSchedule)
+
+		isEqual(t, true, ok)
+		isEqual(t, steps.Max, got.Max)
+
+		for i := range steps.Steps {
+			isEqual(t, steps.Steps[i], got.Steps[i])
+		}
+
+		return
+	}
+
+	isEqual(t, wants, got)
 }
 
 func isEqual[T comparable](t *testing.T, wants, got T) {

--- a/schedule/builder/builder_test.go
+++ b/schedule/builder/builder_test.go
@@ -1,0 +1,212 @@
+package builder
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/zalgonoise/micron/schedule/cronlex"
+	"github.com/zalgonoise/micron/schedule/resolve"
+)
+
+func TestBuild(t *testing.T) {
+	for _, testcase := range []struct {
+		name      string
+		resolvers []Resolver
+		wants     cronlex.Schedule
+		err       error
+	}{
+		{
+			name: "EveryMinute",
+			resolvers: []Resolver{
+				All().Minutes(),
+			},
+			wants: cronlex.Schedule{
+				Sec: resolve.FixedSchedule{
+					Max: maxSecond,
+					At:  minSecond,
+				},
+				Min:      resolve.Everytime{},
+				Hour:     resolve.Everytime{},
+				DayMonth: resolve.Everytime{},
+				Month:    resolve.Everytime{},
+				DayWeek:  resolve.Everytime{},
+			},
+		},
+		{
+			name: "At5thMonth",
+			resolvers: []Resolver{
+				Every(5).Months(),
+			},
+			wants: cronlex.Schedule{
+				Sec: resolve.FixedSchedule{
+					Max: maxSecond,
+					At:  minSecond,
+				},
+				Min: resolve.FixedSchedule{
+					Max: maxMinute,
+					At:  minMinute,
+				},
+				Hour: resolve.FixedSchedule{
+					Max: maxHour,
+					At:  minHour,
+				},
+				DayMonth: resolve.FixedSchedule{
+					Max: maxDay,
+					At:  minDay,
+				},
+				Month: resolve.FixedSchedule{
+					Max: maxMonth,
+					At:  5,
+				},
+				DayWeek: resolve.Everytime{},
+			},
+		},
+		{
+			name: "RangeMondayToFriday",
+			resolvers: []Resolver{
+				Range(Monday, Friday).Weekdays(),
+			},
+			wants: cronlex.Schedule{
+				Sec: resolve.FixedSchedule{
+					Max: maxSecond,
+					At:  minSecond,
+				},
+				Min: resolve.FixedSchedule{
+					Max: maxMinute,
+					At:  minMinute,
+				},
+				Hour: resolve.FixedSchedule{
+					Max: maxHour,
+					At:  minHour,
+				},
+				DayMonth: resolve.Everytime{},
+				Month:    resolve.Everytime{},
+				DayWeek: resolve.RangeSchedule{
+					Max:  maxWeekday,
+					From: Monday,
+					To:   Friday,
+				},
+			},
+		},
+		{
+			name: "OnAFewDaysOfEveryMonth",
+			resolvers: []Resolver{
+				On(1, 3, 4, 7, 10).MonthDays(),
+			},
+			wants: cronlex.Schedule{
+				Sec: resolve.FixedSchedule{
+					Max: maxSecond,
+					At:  minSecond,
+				},
+				Min: resolve.FixedSchedule{
+					Max: maxMinute,
+					At:  minMinute,
+				},
+				Hour: resolve.FixedSchedule{
+					Max: maxHour,
+					At:  minHour,
+				},
+				DayMonth: resolve.StepSchedule{
+					Max:   maxDay,
+					Steps: []int{1, 3, 4, 7, 10},
+				},
+				Month:   resolve.Everytime{},
+				DayWeek: resolve.Everytime{},
+			},
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			sched, err := Build(testcase.resolvers...)
+
+			isEqual(t, true, errors.Is(err, testcase.err))
+			if steps, ok := testcase.wants.Sec.(resolve.StepSchedule); ok {
+				got, ok := sched.Sec.(resolve.StepSchedule)
+
+				isEqual(t, true, ok)
+
+				isEqual(t, steps.Max, got.Max)
+				for i := range steps.Steps {
+					isEqual(t, steps.Steps[i], got.Steps[i])
+				}
+			} else {
+				isEqual(t, testcase.wants.Sec, sched.Sec)
+			}
+
+			if steps, ok := testcase.wants.Min.(resolve.StepSchedule); ok {
+				got, ok := sched.Min.(resolve.StepSchedule)
+
+				isEqual(t, true, ok)
+
+				isEqual(t, steps.Max, got.Max)
+				for i := range steps.Steps {
+					isEqual(t, steps.Steps[i], got.Steps[i])
+				}
+			} else {
+				isEqual(t, testcase.wants.Min, sched.Min)
+			}
+
+			if steps, ok := testcase.wants.Hour.(resolve.StepSchedule); ok {
+				got, ok := sched.Hour.(resolve.StepSchedule)
+
+				isEqual(t, true, ok)
+
+				isEqual(t, steps.Max, got.Max)
+				for i := range steps.Steps {
+					isEqual(t, steps.Steps[i], got.Steps[i])
+				}
+			} else {
+				isEqual(t, testcase.wants.Hour, sched.Hour)
+			}
+
+			if steps, ok := testcase.wants.DayMonth.(resolve.StepSchedule); ok {
+				got, ok := sched.DayMonth.(resolve.StepSchedule)
+
+				isEqual(t, true, ok)
+
+				isEqual(t, steps.Max, got.Max)
+				for i := range steps.Steps {
+					isEqual(t, steps.Steps[i], got.Steps[i])
+				}
+			} else {
+				isEqual(t, testcase.wants.DayMonth, sched.DayMonth)
+			}
+
+			if steps, ok := testcase.wants.Month.(resolve.StepSchedule); ok {
+				got, ok := sched.Month.(resolve.StepSchedule)
+
+				isEqual(t, true, ok)
+
+				isEqual(t, steps.Max, got.Max)
+				for i := range steps.Steps {
+					isEqual(t, steps.Steps[i], got.Steps[i])
+				}
+			} else {
+				isEqual(t, testcase.wants.Month, sched.Month)
+			}
+
+			if steps, ok := testcase.wants.DayWeek.(resolve.StepSchedule); ok {
+				got, ok := sched.DayWeek.(resolve.StepSchedule)
+
+				isEqual(t, true, ok)
+
+				isEqual(t, steps.Max, got.Max)
+				for i := range steps.Steps {
+					isEqual(t, steps.Steps[i], got.Steps[i])
+				}
+			} else {
+				isEqual(t, testcase.wants.DayWeek, sched.DayWeek)
+			}
+		})
+	}
+}
+
+func isEqual[T comparable](t *testing.T, wants, got T) {
+	if got != wants {
+		t.Errorf("output mismatch error: wanted %v ; got %v", wants, got)
+		t.Fail()
+
+		return
+	}
+
+	t.Logf("output matched expected value: %v", wants)
+}


### PR DESCRIPTION
This PR adds a basic schedule builder, to extend the cronlex.Schedule-type creation beyond than starting off from a cron string.